### PR TITLE
Unsafe eval

### DIFF
--- a/assets/javascripts/pixi_demo.js
+++ b/assets/javascripts/pixi_demo.js
@@ -31,7 +31,9 @@ export default class PixiDemo extends Demo {
       import(/* webpackMode: "eager" */'@pixi/core'),
       import(/* webpackMode: "eager" */"@pixi/settings"),
       import(/* webpackMode: "eager" */"@pixi/ticker"),
-    ]).then(([{Application}, {Renderer, BatchRenderer}, {settings}, {TickerPlugin}]) => {
+      import(/* webpackMode: "eager" */"@pixi/unsafe-eval")
+    ]).then(([{Application}, {BatchRenderer, Renderer, systems}, {settings}, {TickerPlugin}, {install}]) => {
+      install({ systems: systems })
       Renderer.registerPlugin('batch', BatchRenderer)
       Application.registerPlugin(TickerPlugin)
       this.app = new Application({

--- a/lambda/headers/index.js
+++ b/lambda/headers/index.js
@@ -33,7 +33,7 @@ exports.handler = async (event) => {
       "manifest-src 'self'",
       "media-src 'self'",
       "object-src 'none'",
-      "script-src 'self' 'unsafe-eval' 'sha256-V/WaLGhSS+tTPAMDVjFgErm2VGPm+tNBC1rdDJHVkZ0=' https://www.google-analytics.com",
+      "script-src 'self' 'sha256-V/WaLGhSS+tTPAMDVjFgErm2VGPm+tNBC1rdDJHVkZ0=' https://www.google-analytics.com",
       "style-src 'self' 'unsafe-inline'",
     ].join('; ')
   }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,6 +2025,11 @@
         "@pixi/settings": "^5.0.0-rc.3"
       }
     },
+    "@pixi/unsafe-eval": {
+      "version": "5.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@pixi/unsafe-eval/-/unsafe-eval-5.0.0-rc.3.tgz",
+      "integrity": "sha512-RESiuGyZuUssUK1O8PRBUtl/lwhs6EtUGfIfUPNxrgbJ7PeUocFXizcbQRS6tFhpbkbC+iyXFYKOf8ZArIqsRQ=="
+    },
     "@pixi/utils": {
       "version": "5.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.0.0-rc.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "dependencies": {
     "@nuxtjs/google-analytics": "^2.2.0",
+    "@pixi/unsafe-eval": "^5.0.0-rc.3",
     "bulma": "^0.7.4",
     "d3-ease": "^1.0.5",
     "nuxt": "^2.6.2",


### PR DESCRIPTION
Removes `unsafe-eval` from Content-Security-Policy