### PR TITLE
Revert "Bump nuxt-jsonld from 1.4.3 to 1.4.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19076,9 +19076,9 @@
       }
     },
     "nuxt-jsonld": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nuxt-jsonld/-/nuxt-jsonld-1.4.4.tgz",
-      "integrity": "sha512-dpWKXv/deEMOXj7uxycUKbwULMVQRuje55QkVIsSxPFZVuNKX/EODpaavUSM9PzoYHbBGQ1Hfy8bRj/B9eaJ5Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nuxt-jsonld/-/nuxt-jsonld-1.4.3.tgz",
+      "integrity": "sha512-ndzE1fEGI1Fx40R4LWYd8g9Oe0m5DjlwVflWe9cydmtwzL8fKy+jDH1KysMbD9UUl3EXXizra5XsTU2Nn39qvA==",
       "requires": {
         "xxhashjs": "^0.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "d3-ease": "^1.0.5",
     "draco3dgltf": "^1.3.4",
     "nuxt": "^2.9.2",
-    "nuxt-jsonld": "^1.4.4",
+    "nuxt-jsonld": "^1.4.3",
     "pixi-particles": "^4.1.2",
     "pixi.js": "^5.1.3",
     "stats.js": "^0.17.0",


### PR DESCRIPTION
1.4.4 introduces a stack overflow crash on page refresh