### PR TITLE
fix: Replace $default-branch in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [$default-branch]
+    branches: [trunk]
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
  $default-branch only available in workflow templates